### PR TITLE
Potential fix for code scanning alert no. 1: Clear text storage of sensitive information

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,11 +1,97 @@
-let apiKey = localStorage.getItem("OPENAI_API_KEY") || "";
+// Encryption helpers using SubtleCrypto AES-GCM
+async function getKeyMaterial(password) {
+  const enc = new TextEncoder();
+  return window.crypto.subtle.importKey(
+    "raw",
+    enc.encode(password),
+    { name: "PBKDF2" },
+    false,
+    ["deriveKey"]
+  );
+}
 
-document.getElementById("saveKey").onclick = () => {
+async function deriveKey(password, salt, usage = ["encrypt", "decrypt"]) {
+  const keyMaterial = await getKeyMaterial(password);
+  return window.crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: salt,
+      iterations: 100000,
+      hash: "SHA-256"
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    usage
+  );
+}
+
+function arrayBufferToBase64(buffer) {
+  return btoa(String.fromCharCode(...new Uint8Array(buffer)));
+}
+
+function base64ToArrayBuffer(base64) {
+  const binary = atob(base64);
+  const array = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) array[i] = binary.charCodeAt(i);
+  return array.buffer;
+}
+
+async function encryptData(password, data) {
+  const enc = new TextEncoder();
+  const salt = window.crypto.getRandomValues(new Uint8Array(16));
+  const iv = window.crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveKey(password, salt);
+  const encrypted = await window.crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: iv },
+    key,
+    enc.encode(data)
+  );
+  // Store salt + iv + ciphertext (all base64 encoded and joined by ".")
+  return (
+    arrayBufferToBase64(salt.buffer) +
+    "." +
+    arrayBufferToBase64(iv.buffer) +
+    "." +
+    arrayBufferToBase64(encrypted)
+  );
+}
+
+async function decryptData(password, encryptedData) {
+  if (!encryptedData) return "";
+  const [saltB64, ivB64, cipherB64] = encryptedData.split(".");
+  if (!saltB64 || !ivB64 || !cipherB64) throw new Error("Invalid encrypted data format.");
+  const salt = new Uint8Array(base64ToArrayBuffer(saltB64));
+  const iv = new Uint8Array(base64ToArrayBuffer(ivB64));
+  const cipher = base64ToArrayBuffer(cipherB64);
+  const key = await deriveKey(password, salt);
+  const decrypted = await window.crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: iv },
+    key,
+    cipher
+  );
+  return new TextDecoder().decode(decrypted);
+}
+
+// API key management: prompt for passphrase as needed
+let apiKey = "";
+let hasDecrypted = false;
+
+// Optionally, auto load and ask for passphrase if encrypted key exists
+document.getElementById("saveKey").onclick = async () => {
   const value = document.getElementById("apiKey").value.trim();
   if (value) {
-    apiKey = value;
-    localStorage.setItem("OPENAI_API_KEY", apiKey);
-    alert("API key saved (in your browser only).");
+    // Ask user for passphrase (not stored)
+    const passphrase = prompt("Enter a passphrase to encrypt your API key. You'll need this to use the key later:");
+    if (!passphrase) {
+      alert("No passphrase entered. Key not saved.");
+      return;
+    }
+    const encrypted = await encryptData(passphrase, value);
+    localStorage.setItem("OPENAI_API_KEY", encrypted);
+    apiKey = value; // Allow in-memory use
+    hasDecrypted = true;
+    alert("Encrypted API key saved in your browser. Remember your passphrase!");
   }
 };
 
@@ -14,6 +100,28 @@ const userInput = document.getElementById("userInput");
 const sendBtn = document.getElementById("sendBtn");
 
 async function sendMessage() {
+  // Decrypt apiKey if necessary
+  if (!apiKey) {
+    const encrypted = localStorage.getItem("OPENAI_API_KEY");
+    if (encrypted) {
+      let passphrase = prompt("Enter your passphrase to decrypt your API key:");
+      if (!passphrase) {
+        updateLastAssistantMessage("No passphrase provided. Cannot send message.");
+        return;
+      }
+      try {
+        apiKey = await decryptData(passphrase, encrypted);
+        hasDecrypted = true;
+      } catch (e) {
+        updateLastAssistantMessage("Failed to decrypt API key: " + e.message);
+        return;
+      }
+    } else {
+      updateLastAssistantMessage("No API key stored. Please set your key first.");
+      return;
+    }
+  }
+
   const text = userInput.value.trim();
   if (!text) return;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Egriffith-8368/egriffith-8368.github.io/security/code-scanning/1](https://github.com/Egriffith-8368/egriffith-8368.github.io/security/code-scanning/1)

The best way to address this issue is to avoid storing sensitive data like API keys in localStorage as cleartext. To do this securely:
- Encrypt the API key before storing it in localStorage.
- Decrypt it when retrieving for use.
- The encryption key should not be hardcoded; ideally, the user should provide a passphrase (entered alongside the API key) used for encryption and decryption.
- Use the SubtleCrypto API provided by the browser (for AES encryption)—preferred over custom/legacy crypto for Web usage.
- Prompt the user for a passphrase when saving or retrieving the key; this passphrase is never stored.
- Store only the encrypted API key in localStorage.

Required changes:
- Add encryption (before setting in localStorage) and decryption (after retrieving from localStorage) helpers that use `window.crypto.subtle` (`AES-GCM`).
- Prompt for or require an additional passphrase field for the user to provide their passphrase.
- When saving: encrypt with user passphrase → store encrypted value in localStorage.
- When retrieving: decrypt with provided passphrase → use decrypted value in API call.
- Update `apiKey` variable management to handle encrypted storage.

Any methods and imports must be added at the top; the encryption helpers, and minor UI changes for the passphrase prompt, must be introduced where needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
